### PR TITLE
Adds the ability to customize the poison queue name

### DIFF
--- a/src/NServiceBus.Bridge/BridgeConfiguration.cs
+++ b/src/NServiceBus.Bridge/BridgeConfiguration.cs
@@ -15,6 +15,7 @@ namespace NServiceBus.Bridge
         bool autoCreateQueues;
         string autoCreateQueuesIdentity;
         int? maximumConcurrency;
+        string poisonQueue;
 
         internal BridgeConfiguration(string leftName, string rightName, Action<TransportExtensions<TLeft>> leftCustomization, Action<TransportExtensions<TRight>> rightCustomization)
         {
@@ -35,6 +36,11 @@ namespace NServiceBus.Bridge
             this.maximumConcurrency = maximumConcurrency;
         }
 
+        public void SetPoisonQueue(string poisonQueue)
+        {
+            this.poisonQueue = poisonQueue;
+        }
+
         public DistributionPolicy DistributionPolicy { get; } = new DistributionPolicy();
 
         public EndpointInstances EndpointInstances { get; } = new EndpointInstances();
@@ -42,7 +48,7 @@ namespace NServiceBus.Bridge
         public IBridge Create()
         {
             return new Bridge<TLeft,TRight>(LeftName, RightName, autoCreateQueues, autoCreateQueuesIdentity, 
-                EndpointInstances, new InMemorySubscriptionStorage(), DistributionPolicy, "poison",
+                EndpointInstances, new InMemorySubscriptionStorage(), DistributionPolicy, poisonQueue ?? "poison",
                 leftCustomization, rightCustomization, maximumConcurrency);
         }
     }


### PR DESCRIPTION
Currently there is no way to change the poison queue from anything other than "poison". Unless I'm mistaken, this is really the same as the error queue, which we call "error".