### PR TITLE
Make API more intuitive

### DIFF
--- a/src/NServiceBus.Bridge.AcceptanceTests/When_publishing_from_asb_endpoint_oriented.cs
+++ b/src/NServiceBus.Bridge.AcceptanceTests/When_publishing_from_asb_endpoint_oriented.cs
@@ -27,7 +27,7 @@ public class When_publishing_from_asb_endpoint_oriented : NServiceBusAcceptanceT
 
         }).And<MsmqTransport>("Right");
 
-        bridgeConfiguration.TypeGenerator.RegisterKnownType(typeof(MyAsbEvent));
+        bridgeConfiguration.AzureServiceBusOnEndpointOrientedTopology.PublishesEvent(typeof(MyAsbEvent));
         bridgeConfiguration.InterceptForawrding(async (queue, message, dispatch) =>
         {
             using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))

--- a/src/NServiceBus.Bridge/BridgeConfiguration.cs
+++ b/src/NServiceBus.Bridge/BridgeConfiguration.cs
@@ -53,7 +53,7 @@
             this.maximumConcurrency = maximumConcurrency;
         }
 
-        public RuntimeTypeGenerator TypeGenerator { get; } = new RuntimeTypeGenerator();
+        public RuntimeTypeGenerator AzureServiceBusOnEndpointOrientedTopology { get; } = new RuntimeTypeGenerator();
 
         public DistributionPolicy DistributionPolicy { get; } = new DistributionPolicy();
 
@@ -63,7 +63,7 @@
         {
             return new Bridge<TLeft,TRight>(LeftName, RightName, autoCreateQueues, autoCreateQueuesIdentity, 
                 EndpointInstances, subscriptionPersistenceConfig, DistributionPolicy, "poison",
-                leftCustomization, rightCustomization, maximumConcurrency, interceptMethod, TypeGenerator);
+                leftCustomization, rightCustomization, maximumConcurrency, interceptMethod, AzureServiceBusOnEndpointOrientedTopology);
         }
     }
 }

--- a/src/NServiceBus.Bridge/BridgeUnderConstruction.cs
+++ b/src/NServiceBus.Bridge/BridgeUnderConstruction.cs
@@ -5,10 +5,10 @@ namespace NServiceBus.Bridge
 {
     public static class Bridge
     {
-        public static BridgeUnderConstruction<TLeft> Between<TLeft>(string endpointName, Action<TransportExtensions<TLeft>> customization = null)
+        public static BridgeUnderConstruction<TLeft> Between<TLeft>(string endpointBridgeEndName, Action<TransportExtensions<TLeft>> customization = null)
             where TLeft : TransportDefinition, new()
         {
-            return new BridgeUnderConstruction<TLeft>(endpointName, customization);
+            return new BridgeUnderConstruction<TLeft>(endpointBridgeEndName, customization);
         }
     }
 
@@ -24,11 +24,11 @@ namespace NServiceBus.Bridge
             this.leftCustomization = leftCustomization;
         }
 
-        public BridgeConfiguration<TLeft, TRight> And<TRight>(string endpointName,
+        public BridgeConfiguration<TLeft, TRight> And<TRight>(string endpointBridgeEndName,
             Action<TransportExtensions<TRight>> customization = null)
             where TRight : TransportDefinition, new()
         {
-            return new BridgeConfiguration<TLeft, TRight>(leftName, endpointName, leftCustomization, customization);
+            return new BridgeConfiguration<TLeft, TRight>(leftName, endpointBridgeEndName, leftCustomization, customization);
         }
     }
 }

--- a/src/NServiceBus.Bridge/RuntimeTypeGenerator.cs
+++ b/src/NServiceBus.Bridge/RuntimeTypeGenerator.cs
@@ -6,7 +6,7 @@ using System.Reflection.Emit;
 
 public class RuntimeTypeGenerator
 {
-    public void RegisterKnownType(Type knownType)
+    public void PublishesEvent(Type knownType)
     {
         if (knownType == null)
         {


### PR DESCRIPTION
As per our discussion.
- `TypeGenerator.RegisterKnownType()` is solely used by ASB tranport running on `EndpointOrientedTopology`. Renaming it makes it easier to understand what it used for and when shouldn't be used.
- Renaming argument name for `Bridge` API to represent what it is.